### PR TITLE
set job priority on job definition - solves #4

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ CustomBatchBuilder.of(listOfStringData)
   .create(engineConfiguration.getCommandExecutorTxRequired());
 ```
 
-Note: The batch `jobPriority` is only considered when using Job Executor with the corresponding Acquisition Strategy `jobExecutorAcquireByPriority`.
+Note: The batch `jobPriority` is only considered when using Job Executor with the corresponding Acquisition Strategy `jobExecutorAcquireByPriority`. (see _https://docs.camunda.org/manual/latest/user-guide/process-engine/the-job-executor/#job-acquisition[camunda documentation]_) 
 The seed and monitor jobs receive the same priority as the batch.
 
 ## Resources

--- a/README.adoc
+++ b/README.adoc
@@ -19,7 +19,7 @@ With this extension, we want to open the camunda batch functionality to everyone
 
 Camunda batch is really cool for offloading huge workload into small asynchronous pieces of work. E.g.:
 
-* Unclaiming / Updating a hugh list of camunda tasks
+* Unclaiming / Updating a huge list of camunda tasks
 
 ## Get started
 
@@ -74,9 +74,13 @@ CustomBatchBuilder.of(listOfStringData)
   .configuration(engineConfiguration)
   .jobHandler(printStringBatchJobHandler)
   .jobsPerSeed(10)
+  .jobPriority(0L)
   .invocationsPerBatchJob(5)
   .create(engineConfiguration.getCommandExecutorTxRequired());
 ```
+
+Note: The batch `jobPriority` is only considered when using Job Executor with the corresponding Acquisition Strategy `jobExecutorAcquireByPriority`.
+The seed and monitor jobs receive the same priority as the batch.
 
 ## Resources
 

--- a/extension/core/src/test/java/org/camunda/bpm/extension/batch/testhelper/CustomBatchTestHelper.java
+++ b/extension/core/src/test/java/org/camunda/bpm/extension/batch/testhelper/CustomBatchTestHelper.java
@@ -5,6 +5,7 @@ import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.manageme
 import java.util.List;
 
 import org.camunda.bpm.engine.batch.Batch;
+import org.camunda.bpm.engine.impl.batch.BatchMonitorJobHandler;
 import org.camunda.bpm.engine.impl.batch.BatchSeedJobHandler;
 import org.camunda.bpm.engine.management.JobDefinition;
 import org.camunda.bpm.engine.runtime.Job;
@@ -18,8 +19,19 @@ public class CustomBatchTestHelper {
       .singleResult();
   }
 
+  public static JobDefinition getMonitorJobDefinition(Batch batch) {
+    return managementService().createJobDefinitionQuery()
+      .jobDefinitionId(batch.getMonitorJobDefinitionId())
+      .jobType(BatchMonitorJobHandler.TYPE)
+      .singleResult();
+  }
+
   public static Job getSeedJob(Batch batch) {
     return getJobForDefinition(getSeedJobDefinition(batch));
+  }
+
+  public static Job getMonitorJob(Batch batch) {
+    return getJobForDefinition(getMonitorJobDefinition(batch));
   }
 
   public static Job getJobForDefinition(JobDefinition jobDefinition) {

--- a/extension/spring/pom.xml
+++ b/extension/spring/pom.xml
@@ -23,6 +23,12 @@
         <scope>import</scope>
         <type>pom</type>
       </dependency>
+
+      <dependency>
+        <groupId>org.camunda.bpm.springboot</groupId>
+        <artifactId>camunda-bpm-spring-boot-starter</artifactId>
+        <version>${camunda-spring-boot.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -35,7 +41,7 @@
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter</artifactId>
-      <version>${camunda-spring-boot.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
To set the priority of a batch job, the custom batch builder now offers an extra parameter `jobPriority` which sets the `overwritingPriority` of the job definitions when creating the batch. Every belonging seed, monitor and batch job receives the configured priority. 